### PR TITLE
Fix ntrip version text for request header

### DIFF
--- a/ntrip.go
+++ b/ntrip.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	NTRIPVersionHeaderKey     string = "Ntrip-Version"
-	NTRIPVersionHeaderValueV2 string = "NTRIP/2.0"
+	NTRIPVersionHeaderValueV2 string = "Ntrip/2.0"
 )
 
 // It's expected that SourceService implementations will use these errors to signal specific


### PR DESCRIPTION
As far as I can tell, the Ntrip-Version header field value should not be fully capitalized.
Testing the original code against [rtk2go.com](rtk2go.com) triggers a fallback to v1.

Their documentation also shows the desired version: [https://www.use-snip.com/kb/knowledge-base/ntrip-rev1-versus-rev2-formats/](https://www.use-snip.com/kb/knowledge-base/ntrip-rev1-versus-rev2-formats/):
```
GET /mountPt HTTP/1.1<cr><lf>
Host: theCaster.com:2101<cr><lf>
Ntrip-Version: Ntrip/2.0<cr><lf>
User-Agent: NTRIP theSoftware/theRevision<cr><lf>
```
As does the code from Gpsd (although they do have ntrip issues as well):  [https://gitlab.com/gpsd/gpsd/-/blob/master/gpsd/net_ntrip.c#L430](https://gitlab.com/gpsd/gpsd/-/blob/master/gpsd/net_ntrip.c#L430)


